### PR TITLE
Make goober conversions copy blockstates

### DIFF
--- a/src/main/java/com/ninni/species/server/entity/mob/update_2/GooberGoo.java
+++ b/src/main/java/com/ninni/species/server/entity/mob/update_2/GooberGoo.java
@@ -76,7 +76,7 @@ public class GooberGoo extends ThrowableItemProjectile {
 
                                 if (state.getBlock() instanceof DoublePlantBlock && state.getValue(DoublePlantBlock.HALF) == DoubleBlockHalf.UPPER) continue;
 
-                                posBlockStateMap.put(placePos, output.defaultBlockState());
+                                posBlockStateMap.put(placePos, output.withPropertiesOf(state));
                             }
                         }
                     }


### PR DESCRIPTION
The current system forces default state everywhere. This should improve compatibility with other mods (like mine 😛)